### PR TITLE
Stop using deprecated workflow commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - run: pip install cram
       - run: cram test/
 
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: tag
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
         run: |
           # Naive parse on our controlled test file
           version=$(sed -E '/^version: (.*)$/!d; s//\1/' test/package.yaml)
-          echo "::set-output name=version::$version"
-          echo "::set-output name=tag::v$version"
+          cat >> "$GITHUB_OUTPUT" <<EOM
+          version=$version
+          tag=v$version
+          EOM
 
       - name: Assertions on outputs.version
         run: |

--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,5 @@ runs:
         ${{ github.action_path }}/bin/run \
           -r "${{ github.repository }}" \
           -c "${{ github.sha }}" \
-          -t "${{ inputs.tag-prefix }}${{ steps.prep.outputs.result }}"
+          -t "${{ inputs.tag-prefix }}${{ steps.prep.outputs.result }}" \
+          >>"$GITHUB_OUTPUT"

--- a/bin/run
+++ b/bin/run
@@ -130,4 +130,4 @@ gh_curl /git/refs --data @- <<EOM
 }
 EOM
 
-echo "::set-output name=tag::$tag"
+echo "tag=$tag"

--- a/bin/run
+++ b/bin/run
@@ -98,16 +98,16 @@ gh_curl() {
 }
 
 if gh_curl "/git/ref/tags/$tag" &>/dev/null; then
-  echo "Tag $tag exists in $repository already"
+  echo "Tag $tag exists in $repository already" >&2
   exit 0
 fi
 
 if ((dry_run)); then
-  echo "Would create $tag => $commit in $repository"
+  echo "Would create $tag => $commit in $repository" >&2
   exit 0
 fi
 
-echo "Creating $tag => $commit in $repository"
+echo "Creating $tag => $commit in $repository" >&2
 
 if [[ -z "$GITHUB_TOKEN" ]]; then
   echo "Unable to create tag: GITHUB_TOKEN not set" >&2


### PR DESCRIPTION
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
